### PR TITLE
Add SIG Liaison and Ambassador Guide

### DIFF
--- a/SIG-Liaison-and-Ambassador-Guide.md
+++ b/SIG-Liaison-and-Ambassador-Guide.md
@@ -1,0 +1,134 @@
+# OpenAPI Initiative: SIG Liaison & Ambassador Guide
+*A quick-reference one-pager for Industry Standards SIG members*
+
+---
+
+## Executive Summary
+
+Industry groups create standards so their members can work together instead of reinventing the same things in incompatible ways. The OpenAPI Specification does the equivalent for APIs: it gives an industry a shared, machine-readable way to describe how their APIs work, so that different players can build against a common contract and the ecosystem can grow without friction or barriers to entry.
+
+When we say an industry group "aligns" with OpenAPI, we mean the group agrees to describe its APIs using the OpenAPI Specification—a common contract between API providers, their partners, and the tools they all use—so that interoperability becomes the default rather than something each party has to negotiate.
+
+This document is a consensus-building tool. Its goal: help SIG liaisons introduce OpenAPI to non-technical audiences—leadership, standards committees, partner organizations—and land three things:
+
+1. What the OpenAPI Initiative and Specification are, and what they do
+2. Why adopting OpenAPI benefits the industry group and its members
+3. What adoption actually asks of them (less than they think)
+
+---
+
+## What is the OpenAPI Initiative?
+
+The OpenAPI Initiative (OAI) is a self-governing open-source project that operates under the Linux Foundation umbrella. It is community-led and vendor-neutral—no single company controls it—and it brings several complementary specifications together under one banner:
+
+- **The OpenAPI Specification (OAS)**—the standard for describing what an HTTP API does.
+- **Arazzo**—a specification for describing sequences of API calls (workflows) that deliver an outcome across one or more APIs.
+- **Overlay**—a specification for layering changes onto an OpenAPI description without editing the original, useful for translations, customization, and governance.
+
+Together these give an industry a shared toolkit for describing not just individual APIs, but how they are used and adapted in practice.
+
+---
+
+## What is the OpenAPI Specification?
+
+The OpenAPI Specification (OAS) is a standard, agreed-upon way of describing an HTTP API—what operations it offers, what data it expects, and what it returns—in a format that both people and machines can read without access to the source code.
+
+Because it is a widely adopted standard, choosing OpenAPI brings an immediate benefit: a large ecosystem of tools and vendors that already understand it, from documentation generators to testing, code generation, and API gateways.
+
+When different players in an industry agree to describe their APIs the same way, they establish a common language for that industry. That shared description promotes interoperability, and the whole market benefits from the collective tooling and expertise that the standard enables.
+
+**By the numbers:** 31,000+ GitHub stars · 9,200+ forks · Latest release: OAS 3.2 (Sept 2025) · A self-governing project under the Linux Foundation
+
+---
+
+## The problem OpenAPI solves (for non-technical audiences)
+
+In most organizations, APIs already exist—but they are not described in a consistent, discoverable way. The knowledge of what an API does and how to use it lives in a few people's heads or scattered, hand-written docs, rather than in a shared, standard format.
+
+That creates real cost. Teams reinvent capabilities that already exist because they can't find or understand them. Partners spend weeks reverse-engineering an integration. Opportunities are missed simply because the relevant knowledge isn't available when and where it's needed.
+
+OpenAPI addresses this by turning API knowledge into a shared, standardized artifact that anyone—technical or not—can discover, read, and build on.
+
+| Without OpenAPI | With OpenAPI |
+|---|---|
+| APIs exist but aren't described in a consistent way | API behavior is documented in a universal, standard format |
+| Partners reverse-engineer integrations | Partners onboard in hours, not weeks |
+| Teams reinvent capabilities they can't find | Existing capabilities are discoverable and reusable |
+| Compliance teams ask engineers for answers | Compliance teams can audit service definitions directly |
+
+---
+
+## Why should an industry group adopt OpenAPI?
+
+| Their concern | What adoption actually means |
+|---|---|
+| "We have our own API standards" | OpenAPI describes *how* APIs are structured—it works alongside domain-specific standards, not against them |
+| "Our members use different tools" | OpenAPI is tool-neutral. Every major API platform already supports it |
+| "We don't want to cede control" | OAI is a self-governing, vendor-neutral project. No single company owns it |
+| "Our audience isn't technical" | Adopting OpenAPI enables business outcomes: faster integrations, lower onboarding costs, bigger ecosystems |
+
+---
+
+## The non-technical case for adoption
+
+**1. A shared language across teams**
+An OpenAPI description is a standard reference that everyone can read. Business teams, product managers, and partners can understand what a service does without needing engineering knowledge—reducing misunderstandings between technical and non-technical stakeholders.
+
+**2. Faster partnerships and integrations**
+When organizations publish OpenAPI descriptions, partners can quickly understand how to connect systems. This lowers the barrier for collaborations, ecosystem partnerships, and third-party innovation.
+
+**3. Greater transparency and trust**
+OpenAPI makes digital services more visible and understandable. Stakeholders can see what data flows where and what functions exist—improving internal trust and external credibility. When a partner can read exactly what your API does and doesn't expose, that's trust built by design, not by relationship.
+
+**4. Better governance and accountability**
+Leadership can more easily review what digital capabilities exist across the organization—supporting compliance, auditing, and risk management, and encouraging consistent standards across teams.
+
+**5. Ecosystem thinking**
+A standard description lets services become building blocks for other innovations. This helps organizations shift from isolated tools to platform ecosystems, and positions the industry group as shared infrastructure—not just a standards body.
+
+**6. A standard that keeps pace**
+OpenAPI is maintained by a global community and evolves with the industry. Adopting it means your standard inherits that momentum, and signals to members that your API standard is enterprise-ready—supported by a broad community of vendors and adopters.
+
+**7. Supports responsible technology**
+Clear, standard descriptions make it easier to examine how systems behave and what data they use—supporting transparency, oversight, and responsible technology practices.
+
+---
+
+## Your role as SIG Liaison
+
+As a liaison between OAI and an industry standards group, you are the bridge. You don't need to be a technical expert—you need to:
+
+- **Introduce OAI** to the standards group's leadership and champion mutual coordination
+- **Translate** the value of OpenAPI into the group's language (business outcomes, not API specs)
+- **Connect** the right people—OAI's technical leads with the group's technical leads when needed
+- **Share** resources: case studies, tooling lists, examples from similar industry groups
+- **Report back** to the SIG on what the group needs and how OAI can support them
+
+---
+
+## Conversation starters
+
+> *"OpenAPI isn't asking you to change your standard—it's asking you to describe it in a way the whole world can already read."*
+
+> *"When your members ask how to implement your API standard, what do they do today? OpenAPI could change that answer."*
+
+> *"What would it mean for your ecosystem if any developer could onboard to your API standard in an afternoon?"*
+
+> *"If two members built the same integration today, would they even know? A standard description makes existing work discoverable."*
+
+---
+
+## Resources
+
+- OpenAPI Specification: [github.com/OAI/OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification)
+- Arazzo Specification: [github.com/OAI/Arazzo-Specification](https://github.com/OAI/Arazzo-Specification)
+- Overlay Specification: [github.com/OAI/Overlay-Specification](https://github.com/OAI/Overlay-Specification)
+- Industry Standards SIG: [github.com/OAI/sig-industry-standards](https://github.com/OAI/sig-industry-standards)
+- OAI website: [openapis.org](https://www.openapis.org)
+- TSC meetings: Open to the public—check the OAI community calendar
+- Questions? Bring them back to the SIG
+
+---
+
+*Prepared by the OAI Industry Standards SIG*
+*Authors: Pooja Vijay Kumar, Sandeep Chakravartty*


### PR DESCRIPTION
This adds a SIG Liaison and Ambassador Guide — a one-page, non-technical reference that helps SIG liaisons introduce OpenAPI to industry standards groups and make the case for adoption to leadership and partner organizations.

This was originally opened against OAI/community (#21). Per review feedback there (thanks @lornajane, @earth2marsh and @SensibleWood), it has been revised and moved here to the Industry Standards SIG repo, which is the more appropriate home.

Changes made from the review: added a "What is the OpenAPI Initiative?" section covering OAS, Arazzo and Overlay under the Linux Foundation umbrella; reframed the "problem" section away from "gatekeeping" toward APIs existing but not being described consistently; defined what adoption/alignment means (a common contract that promotes interoperability); removed the concrete/engineer analogy in favour of a plain explanation of OpenAPI as a standard description that unlocks an ecosystem; and clarified governance as a self-governing project under the Linux Foundation.

Happy to adjust the file location or wording per maintainer preference. Authors: Pooja Vijay Kumar, Sandeep Chakravartty